### PR TITLE
fix: Enhance accessibility for iframe and object elements

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -796,7 +796,7 @@ A leaflet.
 			<div id="iframe" class="element-container">
 				<h3 class="heading element-name"><code>&lt;iframe&gt;</code>: Inline Frame</h3>
 				<div class="element">
-					<iframe src="index.html">If you see this, your browser does not support the iframe element.</iframe>
+					<iframe src="https://example.com" title="Example Domain page">If you see this, your browser does not support the iframe element.</iframe>
 				</div>
 			</div>
 
@@ -804,7 +804,7 @@ A leaflet.
 			<div id="object" class="element-container">
 				<h3 class="heading element-name"><code>&lt;object&gt;</code>: External Object</h3>
 				<div class="element">
-					<object type="image/jpeg" data={image.src}></object>
+					<object type="image/jpeg" data={image.src}>Mt. Fuji, by Daniel Hehn</object>
 				</div>
 			</div>
 


### PR DESCRIPTION
- Update the iframe source to example.com and add a title.
- Add an alternate text to the object element.