### PR TITLE
fix: Ensure object element has a valid accessible name

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -804,7 +804,7 @@ A leaflet.
 			<div id="object" class="element-container">
 				<h3 class="heading element-name"><code>&lt;object&gt;</code>: External Object</h3>
 				<div class="element">
-					<object type="image/jpeg" data={image.src}>Mt. Fuji, by Daniel Hehn</object>
+					<object type="image/jpeg" data={image.src} aria-label="Mt. Fuji, by Daniel Hehn"><p>Mt. Fuji, by Daniel Hehn</p></object>
 				</div>
 			</div>
 


### PR DESCRIPTION
- Add `aria-label` to the `<object>` element so the accessible name exists even when the image loads.
- Wrap existing fallback text in `<p>` tag tag to strictly follow WCAG Technique H53.